### PR TITLE
Add mod configuration options for Teemo's stats

### DIFF
--- a/modinfo.lua
+++ b/modinfo.lua
@@ -24,3 +24,81 @@ all_clients_require_mod = true
 clients_only_mod = false
 
 server_filter_tags = {"teemo"}
+
+configuration_options = {
+    {
+        name = "health",
+        label = "Health",
+        hover = "Teemo's max health",
+        options = {
+            {description = "75",  data = 75},
+            {description = "100", data = 100},
+            {description = "150", data = 150},
+            {description = "200", data = 200},
+            {description = "250", data = 250},
+        },
+        default = 100,
+    },
+    {
+        name = "hunger",
+        label = "Hunger",
+        hover = "Teemo's max hunger",
+        options = {
+            {description = "75",  data = 75},
+            {description = "100", data = 100},
+            {description = "150", data = 150},
+            {description = "200", data = 200},
+        },
+        default = 100,
+    },
+    {
+        name = "sanity",
+        label = "Sanity",
+        hover = "Teemo's max sanity",
+        options = {
+            {description = "100", data = 100},
+            {description = "150", data = 150},
+            {description = "200", data = 200},
+            {description = "250", data = 250},
+            {description = "300", data = 300},
+        },
+        default = 250,
+    },
+    {
+        name = "damage_multiplier",
+        label = "Damage Multiplier",
+        hover = "Teemo's damage multiplier",
+        options = {
+            {description = "0.75x", data = 0.75},
+            {description = "1.0x",  data = 1.0},
+            {description = "1.25x", data = 1.25},
+            {description = "1.5x",  data = 1.5},
+            {description = "2.0x",  data = 2.0},
+        },
+        default = 1.0,
+    },
+    {
+        name = "absorption",
+        label = "Defense (Absorption)",
+        hover = "Teemo's damage absorption rate",
+        options = {
+            {description = "0%",  data = 0},
+            {description = "10%", data = 0.1},
+            {description = "25%", data = 0.25},
+            {description = "50%", data = 0.5},
+        },
+        default = 0,
+    },
+    {
+        name = "speed_multiplier",
+        label = "Move Speed",
+        hover = "Teemo's movement speed multiplier",
+        options = {
+            {description = "1.0x",  data = 1.0},
+            {description = "1.1x",  data = 1.1},
+            {description = "1.25x", data = 1.25},
+            {description = "1.5x",  data = 1.5},
+        },
+        default = 1.25,
+    },
+}

--- a/modmain.lua
+++ b/modmain.lua
@@ -1,5 +1,13 @@
 GLOBAL.NOXIOUS_TRAP_MAX_STACKS = 5
 
+-- MOD設定値の読み込み
+GLOBAL.TEEMO_HEALTH = GetModConfigData("health") or 100
+GLOBAL.TEEMO_HUNGER = GetModConfigData("hunger") or 100
+GLOBAL.TEEMO_SANITY = GetModConfigData("sanity") or 250
+GLOBAL.TEEMO_DAMAGE_MULT = GetModConfigData("damage_multiplier") or 1.0
+GLOBAL.TEEMO_ABSORPTION = GetModConfigData("absorption") or 0
+GLOBAL.TEEMO_SPEED_MULT = GetModConfigData("speed_multiplier") or 1.25
+
 local STRINGS = GLOBAL.STRINGS
 
 STRINGS.CHARACTER_TITLES.teemo = "Captain Teemo"

--- a/scripts/prefabs/teemo.lua
+++ b/scripts/prefabs/teemo.lua
@@ -73,12 +73,7 @@ end
 
 local function checkCamouflage(inst)
 
-    if inst.components.sanity == nil or inst.components.health == nil then
-        return
-    end
-
-    if inst.components.sanity:GetPercent() < .3 then
-        disableCamouflage(inst)
+    if inst.components.health == nil then
         return
     end
 
@@ -103,7 +98,7 @@ local function onAttacked(inst, data)
         inst.resetMoveQuickTask:Cancel()
     end
     inst.resetMoveQuickTask = inst:DoTaskInTime(5.0, function(inst)
-        inst.components.locomotor.runspeed = TUNING.WILSON_RUN_SPEED * 1.26
+        inst.components.locomotor.runspeed = TUNING.WILSON_RUN_SPEED * TEEMO_SPEED_MULT
         inst.resetMoveQuickTask = nil
     end, inst)
 end
@@ -128,7 +123,7 @@ end
 local function startPassive(inst)
     updCamouflagePrm(inst)
     inst.camouflageTask = inst:DoPeriodicTask(.5, checkCamouflage)
-    inst.components.locomotor.runspeed = TUNING.WILSON_RUN_SPEED * 1.26
+    inst.components.locomotor.runspeed = TUNING.WILSON_RUN_SPEED * TEEMO_SPEED_MULT
 end
 
 local function stopNoxiousTrapRecovery(inst)
@@ -201,9 +196,11 @@ end
 
 local master_postinit = function(inst)
 
-	inst.components.health:SetMaxHealth(100)
-	inst.components.hunger:SetMax(100)
-	inst.components.sanity:SetMax(100)
+	inst.components.health:SetMaxHealth(TEEMO_HEALTH)
+	inst.components.hunger:SetMax(TEEMO_HUNGER)
+	inst.components.sanity:SetMax(TEEMO_SANITY)
+	inst.components.combat.damagemultiplier = TEEMO_DAMAGE_MULT
+	inst.components.health:SetAbsorptionAmount(TEEMO_ABSORPTION)
 
     startPassive(inst)
 


### PR DESCRIPTION
Allow server hosts to customize health, hunger, sanity, damage multiplier, defense absorption, and movement speed through the mod settings screen. Also remove sanity threshold condition from camouflage activation.