### PR TITLE
Add poison food spoilage: poisoned enemies drop stale food

### DIFF
--- a/modinfo.lua
+++ b/modinfo.lua
@@ -250,4 +250,18 @@ configuration_options = {
         },
         default = 20,
     },
+    {
+        name = "poison_spoil_percent",
+        label = "Poison Food Spoilage",
+        hover = "Freshness of food dropped by poisoned enemies (±15% random) / 毒状態の敵がドロップする食料の鮮度（±15%ランダム）",
+        options = {
+            {description = "Off",  data = 0},
+            {description = "90%",  data = 0.9},
+            {description = "80%",  data = 0.8},
+            {description = "70%",  data = 0.7},
+            {description = "60%",  data = 0.6},
+            {description = "50%",  data = 0.5},
+        },
+        default = 0.7,
+    },
 }

--- a/modmain.lua
+++ b/modmain.lua
@@ -11,6 +11,8 @@ GLOBAL.TEEMO_BLIND_DART_DAMAGE = GetModConfigData("blind_dart_damage") or 10
 GLOBAL.TEEMO_BLIND_DART_DOT = GetModConfigData("blind_dart_dot") or 5
 GLOBAL.TEEMO_NOXIOUS_TRAP_DAMAGE = GetModConfigData("noxious_trap_damage") or 20
 GLOBAL.TEEMO_NOXIOUS_TRAP_DOT = GetModConfigData("noxious_trap_dot") or 20
+GLOBAL.TEEMO_POISON_SPOIL_PERCENT = GetModConfigData("poison_spoil_percent")
+if GLOBAL.TEEMO_POISON_SPOIL_PERCENT == nil then GLOBAL.TEEMO_POISON_SPOIL_PERCENT = 0.7 end
 
 local STRINGS = GLOBAL.STRINGS
 

--- a/scripts/components/explosive_noxious_trap.lua
+++ b/scripts/components/explosive_noxious_trap.lua
@@ -1,3 +1,5 @@
+local TeemoPoison = require("teemo_poison_util")
+
 local Explosive_Noxious_Trap = Class(function(self,inst)
     self.inst = inst
     self.explosiveRange = 4
@@ -26,6 +28,8 @@ local function doEndTask(v)
             v.noxiousTrapDamageTask:Cancel()
             v.noxiousTrapDamageTask = nil
         end
+        -- 毒マーク解除（他の毒DOTが残っていなければ）
+        TeemoPoison.unmarkTeemoPoisoned(v)
     end, v)
 end
 
@@ -86,6 +90,11 @@ function Explosive_Noxious_Trap:OnBurnt()
             if v.components.combat and v ~= self.inst then
 
                 if not v:HasTag(nonTarget) and not v:HasTag("companion") then
+
+                    -- 毒による食料腐敗マーク（初撃で倒した場合にも対応するためGetAttackedの前に設定）
+                    if self.explosiveDotDamage > 0 then
+                        TeemoPoison.markTeemoPoisoned(v)
+                    end
 
                     -- 初撃ダメージ（GetAttackedで実ダメージ適用）
                     v.components.combat:GetAttacked(counterPlayer, self.explosiveDamage, nil)

--- a/scripts/prefabs/blind_dart.lua
+++ b/scripts/prefabs/blind_dart.lua
@@ -1,4 +1,6 @@
-local assets = {  
+local TeemoPoison = require("teemo_poison_util")
+
+local assets = {
     Asset("ANIM", "anim/blind_dart.zip"),
 	Asset("ANIM", "anim/swap_blind_dart.zip"),
 
@@ -90,6 +92,8 @@ local function doToxicShotEndTask(target)
             target.toxicShotDamageTask = nil
         end
         target.toxicShotEndTask = nil
+        -- 毒マーク解除（他の毒DOTが残っていなければ）
+        TeemoPoison.unmarkTeemoPoisoned(target)
     end)
 end
 
@@ -102,6 +106,9 @@ local function doToxicShot(target)
     if TEEMO_BLIND_DART_DOT <= 0 then
         return
     end
+
+    -- 毒による食料腐敗マーク（冗長性のため、teemo.luaのonattackotherでもマーク済み）
+    TeemoPoison.markTeemoPoisoned(target)
 
     -- DOT発動中は効果延長のみ
     if target.toxicShotDamageTask ~= nil then

--- a/scripts/prefabs/teemo.lua
+++ b/scripts/prefabs/teemo.lua
@@ -1,5 +1,6 @@
 
 local MakePlayerCharacter = require ("prefabs/player_common")
+local TeemoPoison = require("teemo_poison_util")
 
 local assets = {
     Asset( "ANIM", "anim/teemo.zip" ),
@@ -240,7 +241,13 @@ local master_postinit = function(inst)
     inst:ListenForEvent("oneatsomething", function() disableCamouflage(inst) end)
     inst:ListenForEvent("oneaten", function() disableCamouflage(inst) end)
     inst:ListenForEvent("working", function() disableCamouflage(inst) end)
-    inst:ListenForEvent("onattackother", function() disableCamouflage(inst) end)
+    inst:ListenForEvent("onattackother", function(inst, data)
+        disableCamouflage(inst)
+        -- Blind Dart攻撃時、GetAttackedの前に毒マークを設定（初撃即死でも食料腐敗を適用）
+        if data and data.weapon and data.weapon:HasTag("blowdart") and data.target then
+            TeemoPoison.markTeemoPoisoned(data.target)
+        end
+    end)
     inst:ListenForEvent("attacked", onAttacked)
     inst:ListenForEvent("death", onDeath)
     inst:ListenForEvent("ms_respawnedfromghost", function()

--- a/scripts/teemo_poison_util.lua
+++ b/scripts/teemo_poison_util.lua
@@ -1,0 +1,47 @@
+-- Teemo Poison Loot Utility
+-- 毒状態で死んだ敵のドロップ食料を腐敗させる
+
+local function onLootSpawned(inst, data)
+    -- 設定で無効化されている場合はスキップ
+    if TEEMO_POISON_SPOIL_PERCENT == nil or TEEMO_POISON_SPOIL_PERCENT <= 0 then
+        return
+    end
+
+    if data.loot == nil then return end
+
+    -- 食用かつ腐敗可能なアイテムのみ対象
+    if data.loot.components.edible == nil then return end
+    if data.loot.components.perishable == nil then return end
+
+    -- 中心値 ± 15% のランダムで鮮度を決定（0〜1にクランプ）
+    local variance = (math.random() * 2 - 1) * 0.15
+    local spoilPercent = math.max(0, math.min(1, TEEMO_POISON_SPOIL_PERCENT + variance))
+
+    -- 現在の鮮度がランダム値より高い場合のみ腐敗させる
+    local currentPercent = data.loot.components.perishable:GetPercent()
+    if currentPercent > spoilPercent then
+        data.loot.components.perishable:SetPercent(spoilPercent)
+    end
+end
+
+local function markTeemoPoisoned(target)
+    if not target:IsValid() then return end
+    if target._teemoPoisoned then return end
+    target._teemoPoisoned = true
+    target:ListenForEvent("loot_prefab_spawned", onLootSpawned)
+end
+
+local function unmarkTeemoPoisoned(target)
+    if not target:IsValid() then return end
+    -- 他の毒DOTが残っている場合はマークを維持
+    if target.toxicShotDamageTask ~= nil then return end
+    if target.noxiousTrapDamageTask ~= nil then return end
+    if not target._teemoPoisoned then return end
+    target._teemoPoisoned = nil
+    target:RemoveEventCallback("loot_prefab_spawned", onLootSpawned)
+end
+
+return {
+    markTeemoPoisoned = markTeemoPoisoned,
+    unmarkTeemoPoisoned = unmarkTeemoPoisoned,
+}


### PR DESCRIPTION
Enemies killed while poisoned by Blind Dart or Noxious Trap now drop food with reduced freshness (default 70% ± 15% random). Configurable via mod settings (Off/90%/80%/70%/60%/50%).