### PR TITLE
Add mushroom immunity passive and character bio display

### DIFF
--- a/modinfo.lua
+++ b/modinfo.lua
@@ -264,4 +264,14 @@ configuration_options = {
         },
         default = 0.7,
     },
+    {
+        name = "mushroom_immunity",
+        label = "Mushroom Immunity",
+        hover = "Negate mushroom negative effects / キノコのデメリット無効化",
+        options = {
+            {description = "On",  data = true},
+            {description = "Off", data = false},
+        },
+        default = true,
+    },
 }

--- a/modmain.lua
+++ b/modmain.lua
@@ -13,6 +13,8 @@ GLOBAL.TEEMO_NOXIOUS_TRAP_DAMAGE = GetModConfigData("noxious_trap_damage") or 20
 GLOBAL.TEEMO_NOXIOUS_TRAP_DOT = GetModConfigData("noxious_trap_dot") or 20
 GLOBAL.TEEMO_POISON_SPOIL_PERCENT = GetModConfigData("poison_spoil_percent")
 if GLOBAL.TEEMO_POISON_SPOIL_PERCENT == nil then GLOBAL.TEEMO_POISON_SPOIL_PERCENT = 0.7 end
+GLOBAL.TEEMO_MUSHROOM_IMMUNITY = GetModConfigData("mushroom_immunity")
+if GLOBAL.TEEMO_MUSHROOM_IMMUNITY == nil then GLOBAL.TEEMO_MUSHROOM_IMMUNITY = true end
 
 -- キャラクター選択画面のステータス表示用（TUNINGテーブルに登録）
 GLOBAL.TUNING.TEEMO_HEALTH = GLOBAL.TEEMO_HEALTH
@@ -28,8 +30,9 @@ local STRINGS = GLOBAL.STRINGS
 
 STRINGS.CHARACTER_TITLES.teemo = "Captain Teemo"
 STRINGS.CHARACTER_NAMES.teemo = "Captain Teemo"
-STRINGS.CHARACTER_DESCRIPTIONS.teemo = "Size doesn't mean everything."
+STRINGS.CHARACTER_DESCRIPTIONS.teemo = "*Goes invisible when standing still\n*Has a poison blowdart\n*Can deploy Noxious Traps\n*Expert at eating mushrooms"
 STRINGS.CHARACTER_QUOTES.teemo = "\"on duty !! \""
+STRINGS.CHARACTER_ABOUTME.teemo = "Size doesn't mean everything."
 STRINGS.CHARACTERS.TEEMO = GLOBAL.require "speech_teemo"
 STRINGS.NAMES.TEEMO = "Teemo"
 STRINGS.SKIN_NAMES.teemo_none = "Teemo"
@@ -110,6 +113,18 @@ AddModCharacter("teemo", "MALE", skin_modes)
 AddMinimapAtlas("images/map_icons/teemo.xml")
 
 GLOBAL.PREFAB_SKINS["teemo"] = { "teemo_none" }
+
+-- パッシブ「キノコの達人」: 月キノコの睡眠をテーモのみ無効化
+if GLOBAL.TEEMO_MUSHROOM_IMMUNITY then
+    AddPrefabPostInit("moon_cap", function(inst)
+        if not GLOBAL.TheWorld.ismastersim then return end
+        local _oneaten = inst.components.edible.oneaten
+        inst.components.edible:SetOnEatenFn(function(inst, eater)
+            if eater:HasTag("teemo") then return end
+            if _oneaten ~= nil then _oneaten(inst, eater) end
+        end)
+    end)
+end
 
 -- アイテムの名前 item name
 STRINGS.NAMES.BLIND_DART = "Blind Dart"

--- a/scripts/prefabs/teemo.lua
+++ b/scripts/prefabs/teemo.lua
@@ -12,6 +12,23 @@ local NOXIOUS_TRAP_MAX_STACKS = NOXIOUS_TRAP_MAX_STACKS
 local NOXIOUS_TRAP_INITIAL_STACKS = 3
 local NOXIOUS_TRAP_RECOVERY_INTERVAL = 30
 
+-- パッシブ「キノコの達人」: キノコのマイナスステータスを無効化
+local MUSHROOM_PREFABS = {
+    red_cap = true, red_cap_cooked = true,
+    green_cap = true, green_cap_cooked = true,
+    blue_cap = true, blue_cap_cooked = true,
+    moon_cap = true, moon_cap_cooked = true,
+}
+
+local function mushroomStatsMod(inst, health_delta, hunger_delta, sanity_delta, food, feeder)
+    if food ~= nil and MUSHROOM_PREFABS[food.prefab] then
+        if health_delta < 0 then health_delta = 0 end
+        if hunger_delta < 0 then hunger_delta = 0 end
+        if sanity_delta < 0 then sanity_delta = 0 end
+    end
+    return health_delta, hunger_delta, sanity_delta
+end
+
 local start_inv = {
     "blind_dart",
     -- "sewing_kit",
@@ -230,6 +247,11 @@ local master_postinit = function(inst)
 	inst.components.sanity:SetMax(TEEMO_SANITY)
 	inst.components.combat.damagemultiplier = TEEMO_DAMAGE_MULT
 	inst.components.health:SetAbsorptionAmount(TEEMO_ABSORPTION)
+
+    -- パッシブ「キノコの達人」
+    if TEEMO_MUSHROOM_IMMUNITY then
+        inst.components.eater.custom_stats_mod_fn = mushroomStatsMod
+    end
 
     startPassive(inst)
 


### PR DESCRIPTION
- Mushroom Expert passive: negate negative stat effects from all mushrooms, and disable moon cap sleep for Teemo only
- Add configurable mushroom_immunity setting (On/Off, default On)
- Update character selection screen: trait list, about me text